### PR TITLE
Use always newest version of php-cs-fixer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ LABEL "repository"="http://github.com/oskarstark/php-cs-fixer-ga"
 LABEL "homepage"="http://github.com/actions"
 LABEL "maintainer"="Oskar Stark <oskarstark@googlemail.com>"
 
-RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.1/php-cs-fixer.phar -O php-cs-fixer \
+RUN wget https://cs.symfony.com/download/php-cs-fixer-v2.phar -O php-cs-fixer \
     && chmod a+x php-cs-fixer \
     && mv php-cs-fixer /usr/local/bin/php-cs-fixer
 


### PR DESCRIPTION
I would use the newest version or make it configureable which version it should use and make it possible to use always the latest version.