### PR TITLE
Add git package to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL "repository"="http://github.com/oskarstark/php-cs-fixer-ga"
 LABEL "homepage"="http://github.com/actions"
 LABEL "maintainer"="Oskar Stark <oskarstark@googlemail.com>"
 
+RUN apk add git
 RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.16.4/php-cs-fixer.phar -O php-cs-fixer \
     && chmod a+x php-cs-fixer \
     && mv php-cs-fixer /usr/local/bin/php-cs-fixer


### PR DESCRIPTION
this is needed when rules file uses `git` command:

```
➔ docker run --rm -it -w=/app -v ${PWD}:/app oskarstark/php-cs-fixer-ga:latest
PHP CS Fixer 2.16.4 Yellow Bird by Fabien Potencier and Dariusz Ruminski (1023c34)

In ProjectRootDetector.php line 19:

  Unable to get project root dir: The command "git rev-parse --show-toplevel" failed.

  Exit Code: 127(Command not found)

  Working directory: /app

  Output:
  ================


  Error Output:
  ================
  sh: git: not found


fix [--path-mode PATH-MODE] [--allow-risky ALLOW-RISKY] [--config CONFIG] [--dry-run] [--rules RULES] [--using-cache USING-CACHE] [--cache-file CACHE-FILE] [--diff] [--diff-format DIFF-FORMAT] [--format FORMAT] [--stop-on-violation] [--show-progress SHOW-PROGRESS] [--] [<path>]...

➔
```