### PR TITLE
Install several PHP extensions to make their functions available

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,29 @@ LABEL "repository"="http://github.com/oskarstark/php-cs-fixer-ga"
 LABEL "homepage"="http://github.com/actions"
 LABEL "maintainer"="Oskar Stark <oskarstark@googlemail.com>"
 
+RUN apk add --no-cache --virtual .build-deps \
+        icu-dev \
+        gmp-dev \
+        libjpeg-turbo-dev \
+        libpng-dev \
+        libwebp-dev \
+        zlib-dev \
+    && docker-php-ext-configure gd --with-jpeg --with-webp \
+    && docker-php-ext-install \
+        exif \
+        gd \
+        gmp \
+        intl \
+        opcache \
+    && runDeps="$( \
+            scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
+                | tr ',' '\n' \
+                | sort -u \
+                | awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
+        )" \
+    && apk add --virtual .phpexts-rundeps $runDeps \
+    && apk del .build-deps
+
 RUN wget https://github.com/FriendsOfPHP/PHP-CS-Fixer/releases/download/v2.18.3/php-cs-fixer.phar -O php-cs-fixer \
     && chmod a+x php-cs-fixer \
     && mv php-cs-fixer /usr/local/bin/php-cs-fixer


### PR DESCRIPTION
The `native_function_invocation` fixer relies on `get_defined_functions()` for
prefixing the native functions with the backslash.

Consider a source file like:

    <?php
    opcache_reset();
    stat('test.png');
    imagecreatefrompng('test.png');

And a configuration like:

    <?php
    $finder = PhpCsFixer\Finder::create()
        ->in(__DIR__);

    return (new PhpCsFixer\Config())
        ->setRiskyAllowed(true)
        ->setRules([
            'native_function_invocation' => true,
        ])
        ->setFinder($finder);

Before this change:

       1) test.php
          ---------- begin diff ----------
    --- Original
    +++ New
    @@ @@
     <?php
     opcache_reset();
    -stat('test.png');
    +\stat('test.png');
     imagecreatefrompng('test.png');

          ----------- end diff -----------

After this change:

       1) test.php
          ---------- begin diff ----------
    --- Original
    +++ New
    @@ @@
     <?php
    -opcache_reset();
    -stat('test.png');
    -imagecreatefrompng('test.png');
    +\opcache_reset();
    +\stat('test.png');
    +\imagecreatefrompng('test.png');

          ----------- end diff -----------
