### PR TITLE
Do not pin the PHP version to 8.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0.1-alpine
+FROM php:8.0-alpine
 
 LABEL "com.github.actions.name"="OSKAR-PHP-CS-Fixer"
 LABEL "com.github.actions.description"="check php files"


### PR DESCRIPTION
The action will miss out on PHP bugfixes otherwise. As of this commit the current PHP version is 8.0.3.