### PR TITLE
Update Dockerfile to use PHP 8.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.0-alpine
+FROM php:8.1-alpine
 
 LABEL "com.github.actions.name"="OSKAR-PHP-CS-Fixer"
 LABEL "com.github.actions.description"="check php files"


### PR DESCRIPTION
Update Dockerfile version to use latest PHP version in order to provide support on latest PHP 8.1 features