### PR TITLE
Fix missing quote

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,4 +12,4 @@ name: 'OSKAR-PHP-CS-Fixer'
 
 runs:
     using: 'docker'
-    image: 'docker://oskarstark/php-cs-fixer-ga:3.14.3
+    image: 'docker://oskarstark/php-cs-fixer-ga:3.14.3'


### PR DESCRIPTION
Due to missing quote, the builds fail with

```
Error: OskarStark/php-cs-fixer-ga/master/action.yml:
Error: OskarStark/php-cs-fixer-ga/master/action.yml: (Line: 15, Col: 12, Idx: 259) - (Line: 16, Col: 1, Idx: 303): While scanning a quoted scalar, find unexpected end of stream.
Error: System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'. The type 'MappingToken' was expected.
   at GitHub.DistributedTask.ObjectTemplating.Tokens.TemplateTokenExtensions.AssertMapping(TemplateToken value, String objectDescription)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Fail to load OskarStark/php-cs-fixer-ga/master/action.yml
```