### PR TITLE
Add example in documentation to run action only for changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,39 @@ jobs:
 
 **You can copy/paste the `.github/` folder (under `examples/`) to your project and that's all!**
 
+## Usage with only changed files
+
+It is also possible to run PHP-CS-Fixer just on your changed files. To achieve this, you can use the [`tj-actions/changed-files`](https://github.com/tj-actions/changed-files) action to retrieve the changed files and subsequently use the result to create extra arguments with `---path-mode=intersection`.
+
+```
+on: [push, pull_request]
+name: Main
+jobs:
+  php-cs-fixer:
+    name: PHP-CS-Fixer
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v38
+
+      - name: Get extra arguments for PHP-CS-Fixer
+        id: phpcs-intersection
+        run: |
+          CHANGED_FILES=$(echo "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" | tr ' ' '\n')
+          if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php-cs-fixer(\\.dist)?\\.php|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
+          echo "PHPCS_EXTRA_ARGS<<EOF" >> $GITHUB_ENV
+          echo "$EXTRA_ARGS" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - name: PHP-CS-Fixer
+        uses: docker://oskarstark/php-cs-fixer-ga
+        with:
+          args: --config=.php-cs-fixer.dist.php -v --dry-run --stop-on-violation --using-cache=no ${{ env.PHPCS_EXTRA_ARGS }}"
+```
+
 ## Docker
 
 A Docker image is built automatically and located here:


### PR DESCRIPTION
Fixes #12 

---

1. In order to run the action on just the changed files, we use [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to get the diff.
2. Next we construct a list of (intersection) arguments from the changed files.
   1.  This code is derived from the PHP-CS-Fixer documentation, section ["Using PHP CS Fixer on CI"](https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/doc/usage.rst#using-php-cs-fixer-on-ci).
   2. As the `$EXTRA_ARGS` is a multiline string, we add it to `$GITHUB_ENV` (If there's a better way for this, please let me know).
3. We pass the arguments to PHP-CS-Fixer using `${{ env.PHPCS_EXTRA_ARGS }}"`.

---

As sidenote, if you do not want or use this action but instead have `php-cs-fixer` as dev dependency in your application, the steps are somewhat simpler as you can do number 2 and 3 in a single step without the need for saving the variable to the environment.

```yaml
      - name: Get changed files
        id: changed-files
        uses: tj-actions/changed-files@v38

      - name: PHP CS Fixer
        run: |
          CHANGED_FILES=$(echo "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" | tr ' ' '\n')
          if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php-cs-fixer(\\.dist)?\\.php|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
          vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.dist.php -v --dry-run --diff --using-cache=no ${EXTRA_ARGS}
```