### PR TITLE
Docs: Update usage with only changed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ jobs:
       - name: Get extra arguments for PHP-CS-Fixer
         id: phpcs-intersection
         run: |
-          CHANGED_FILES=$(echo "${{ steps.changed-files.outputs.all_changed_and_modified_files }}" | tr ' ' '\n')
+          CHANGED_FILES=$(echo "${{ steps.changed-files.outputs.all_changed_files }}" | tr ' ' '\n')
           if ! echo "${CHANGED_FILES}" | grep -qE "^(\\.php-cs-fixer(\\.dist)?\\.php|composer\\.lock)$"; then EXTRA_ARGS=$(printf -- '--path-mode=intersection\n--\n%s' "${CHANGED_FILES}"); else EXTRA_ARGS=''; fi
           echo "PHPCS_EXTRA_ARGS<<EOF" >> $GITHUB_ENV
           echo "$EXTRA_ARGS" >> $GITHUB_ENV


### PR DESCRIPTION
Fixes running php-cs-fixer on deleted 

![image](https://github.com/OskarStark/php-cs-fixer-ga/assets/5685929/5255713d-5ddd-43ba-946a-87b87504f9fb)


change from all_changed_and_modified_files to all_changed_files

only added, copied, modified and renamed files are needed

https://github.com/tj-actions/changed-files/tree/v38.2.2?tab=readme-ov-file#outputs-

