### PR TITLE
Use PHP 8.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.4-alpine
+FROM php:8.5-alpine
 
 LABEL "com.github.actions.name"="OSKAR-PHP-CS-Fixer"
 LABEL "com.github.actions.description"="check php files"


### PR DESCRIPTION
Given PHP-CS-Fixer v3.91.0 introduces official support for PHP 8.5, it might be interesting to update this action's PHP version accordingly.